### PR TITLE
Config and YAML

### DIFF
--- a/lib/sheepsafe/config.rb
+++ b/lib/sheepsafe/config.rb
@@ -8,9 +8,9 @@ module Sheepsafe
     ARRAY_ATTRS = %w(trusted_names)
 
     def self.load_config
-      File.open(FILE) {|f| YAML.load(f) }
-    rescue
-      raise "Unable to read ~/sheepsafe.yml; please run sheepsafe-install"
+      YAML.load_file(FILE)
+    rescue Errno::ENOENT
+      raise "Unable to read ~/.sheepsafe.yml; please run sheepsafe-install"
     end
 
     attr_reader :config
@@ -30,7 +30,7 @@ module Sheepsafe
     end
 
     def write
-      File.open(FILE, "w") {|f| f << YAML.dump(@config) }
+      File.open(FILE, "w") {|f| f << YAML.dump(config) }
     end
   end
 end


### PR DESCRIPTION
Hi Nick,

I've forked sheepsafe and changed a couple of things I thought you might be interested in. Here's a summary of what's in this pull request:
- I've changed the message that gets logged when `~/.sheepsafe` can't be found to use the same path as the one in `SheepSafe::Config::FILE`
- Use `YAML.load_file` when reading the config file
- Replace the use of the `@config` instance variable in `#write` with a call to the `#config` attribute reader, which is used elsewhere in `Config` already.

All the tests are passing. I have another pull request I'm about to send but I'm not sure you'll want these changes in your master branch.
