### PR TITLE
Growl

### DIFF
--- a/lib/sheepsafe/controller.rb
+++ b/lib/sheepsafe/controller.rb
@@ -1,6 +1,9 @@
 require 'daemons'
 require 'logger'
-require 'growl'
+begin
+  require 'growl'
+rescue LoadError
+end
 
 module Sheepsafe
   class Controller
@@ -65,21 +68,17 @@ module Sheepsafe
     end
 
     def notify_ok(msg)
-      check_growl_installed
-      Growl.notify_ok(msg)
+      when_growl_available { Growl.notify_ok(msg) }
       log(msg)
     end
 
     def notify_warning(msg)
-      check_growl_installed
-      Growl.notify_warning(msg)
+      when_growl_available { Growl.notify_warning(msg) }
       log(msg)
     end
 
-    def check_growl_installed
-      unless Growl.installed?
-        log("WARNING: Growl not installed (probably couldn't find growlnotify in PATH: #{ENV['PATH']})")
-      end
+    def when_growl_available(&block)
+      block.call if defined?(Growl)
     end
 
     def log(msg)


### PR DESCRIPTION
I don't know if you'll like this change but I wanted a way to prevent using Growl if it's not available instead of requiring it and logging when it's not installed properly. I think Growl's an optional dependency and tried to come up with the quickest way of using it only when present.

Is `defined?(Growl)` a good enough check? Let me know what you think.

Thanks for sheepsafe. Pretty cool stuff.
