### PR TITLE
fix for yaml parsing issue (missing highline require)

### DIFF
--- a/lib/sheepsafe/config.rb
+++ b/lib/sheepsafe/config.rb
@@ -1,5 +1,5 @@
 require 'yaml'
-
+require 'highline/import'
 module Sheepsafe
   class Config
     FILE = File.expand_path('~/.sheepsafe/sheepsafe.yml')


### PR DESCRIPTION
The yaml file is created with references to highline, but when it is loaded in again at startup, the highline classes are not reference, and yaml complains about:
YAML.load_file(f)
TypeError: invalid subclass from <....>  yaml.rb:133:in `transfer'
